### PR TITLE
Don't autoload ActionController::Base (wait for Rails to load)

### DIFF
--- a/lib/action_interceptor/action_controller/base.rb
+++ b/lib/action_interceptor/action_controller/base.rb
@@ -90,4 +90,6 @@ module ActionInterceptor
   end
 end
 
-ActionController::Base.send :include, ActionInterceptor::ActionController::Base
+ActiveSupport.on_load(:action_controller_base) do
+  ActionController::Base.send :include, ActionInterceptor::ActionController::Base
+end

--- a/lib/action_interceptor/version.rb
+++ b/lib/action_interceptor/version.rb
@@ -1,3 +1,3 @@
 module ActionInterceptor
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -8,7 +8,7 @@ require "action_interceptor"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Prevents warnings, maybe required for Rails 7.